### PR TITLE
ボタンのテキスト位置を中央に変更

### DIFF
--- a/KizunaAiChanAlarm/Alarm.storyboard
+++ b/KizunaAiChanAlarm/Alarm.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="3Au-U0-PcE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="3Au-U0-PcE">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -159,7 +159,6 @@
                                             <constraint firstAttribute="width" constant="120" id="PsT-Vq-O6h"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="18"/>
-                                        <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" title="Reset Alarm" backgroundImage="button">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
@@ -177,7 +176,6 @@
                                             <constraint firstAttribute="width" constant="120" id="uWo-uO-SW4"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="18"/>
-                                        <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" title="Set Alarm" backgroundImage="button">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
@@ -221,7 +219,7 @@
     </scenes>
     <resources>
         <image name="aichan" width="427" height="240"/>
-        <image name="button" width="1024" height="410"/>
+        <image name="button" width="1033" height="422"/>
         <image name="clock_32" width="32" height="32"/>
     </resources>
 </document>

--- a/KizunaAiChanAlarm/Website.storyboard
+++ b/KizunaAiChanAlarm/Website.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ByO-Bh-LDW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ByO-Bh-LDW">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -32,8 +32,7 @@
                                             <constraint firstAttribute="height" constant="80" id="eWo-RE-wUL"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="28"/>
-                                        <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
-                                        <state key="normal" title="A.I.channel " backgroundImage="button">
+                                        <state key="normal" title="A.I.Channel " backgroundImage="button">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
                                         <connections>
@@ -47,7 +46,6 @@
                                             <constraint firstAttribute="width" constant="240" id="DZE-PO-VOd"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="28"/>
-                                        <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" title="A.I.Games" backgroundImage="button">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
@@ -62,7 +60,6 @@
                                             <constraint firstAttribute="height" constant="80" id="g9C-Wq-8Om"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="28"/>
-                                        <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" title="Oficial Website" backgroundImage="button">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
@@ -90,7 +87,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="button" width="1024" height="410"/>
+        <image name="button" width="1033" height="422"/>
         <image name="pc_32" width="32" height="32"/>
     </resources>
 </document>


### PR DESCRIPTION
ボタンの背景画像変更によって、文字を上にずらす必要がなくなった